### PR TITLE
fix: display default avatar if none set

### DIFF
--- a/src/addons/Zentro/DiscordCA/ConnectedAccount/ProviderData/Discord.php
+++ b/src/addons/Zentro/DiscordCA/ConnectedAccount/ProviderData/Discord.php
@@ -38,7 +38,14 @@ class Discord extends \XF\ConnectedAccount\ProviderData\AbstractProviderData
 	{
 		$providerKey = $this->getProviderKey();
 		$avatar = $this->requestFromEndpoint('avatar');
-		
-		return 'https://cdn.discordapp.com/avatars/'.$providerKey.'/'.$avatar.'.png';
+
+        if($avatar) {
+            return 'https://cdn.discordapp.com/avatars/' . $providerKey . '/' . $avatar . '.png';
+        }
+        else {
+            //discord has 5 default avatars
+           $defaultAvatarIndex = random_int(0, 4);
+           return "https://cdn.discordapp.com/embed/avatars/" . $defaultAvatarIndex . '.png';
+        }
 	}
 }


### PR DESCRIPTION
this PR fixes no avatar showing when you didnt set a custom one on discord.

before: 
![{47FC954C-05D8-49EB-84E6-B4DC1F0C48AD}](https://github.com/user-attachments/assets/8a4b7cb4-d9e7-451d-9112-25e18a0775fd)

after: 
![{565C552F-9420-45B1-AD15-F2F283B8DE1D}](https://github.com/user-attachments/assets/4a2793da-5b0c-49a7-aa81-1e0201c6fcaa)
